### PR TITLE
Fix output encoding.

### DIFF
--- a/finishline
+++ b/finishline
@@ -375,4 +375,6 @@ if __name__ == '__main__':
     issues = pull_issues(client, args)
     data = collate_issues(client, args, issues)
     output = render(args.template, args, data)
-    print(six.u(output))
+    if isinstance(output, six.text_type):
+        output = output.encode('utf-8')
+    print(output)


### PR DESCRIPTION
Outputs from the program should be binary encoded.  Without this, python will
do the best it can and try to coerce the output to binary and implicitly encode
it with whatever the locale says.  For many people this is ascii, and for many
people this breaks.

Being explicit about the output encoding gets the script moving again.