### PR TITLE
finishline: Fix printing on Python 3

### DIFF
--- a/finishline
+++ b/finishline
@@ -377,4 +377,10 @@ if __name__ == '__main__':
     output = render(args.template, args, data)
     if isinstance(output, six.text_type):
         output = output.encode('utf-8')
+        try:
+            # Since we are supporting python 2 and 3 we need
+            # to force ascii encoding before printing for python 3
+            output = str(output, encoding='ascii')
+        except:
+            pass
     print(output)


### PR DESCRIPTION
Without turning the result to ascii the resulting ``print`` doesn't render the newlines. This attempts to force to ascii which will work on Python 3, and fail (and then ``pass``) on Python 2.