### PR TITLE
Remove superfluous decode in email template

### DIFF
--- a/templates/threebean/email.md
+++ b/templates/threebean/email.md
@@ -1,5 +1,5 @@
 {{title}}
-{% if subtitle %}{{subtitle.decode('utf-8')}}
+{% if subtitle %}{{subtitle}}
 {% endif %}
 Inbetween these email updates, you should be able to find our latest status at:
 https://docs.google.com/presentation/d/1nupBVPwzWeUP6n-vJh5YEhYoHjecCkzFXQvt9V0GG88/edit


### PR DESCRIPTION
The factory email template included a variable string decode(utf-8) call
which is no longer necessary after my recent change to decode strings
earlier on in the code. This extra call to decode now causes a
stacktrace.