### PR TITLE
Disable Mosiac for Factory 2.0 for this quarter

### DIFF
--- a/factory.conf
+++ b/factory.conf
@@ -20,7 +20,7 @@ hide_epics=DEVOPSA-3635,FACTORY-2725,FACTORY-2257,FACTORY-3097,FACTORY-3018,FACT
 include_epics=FACTORY-3375,FACTORY-3360,FACTORY-2937,FACTORY-3629,FACTORY-3641,FACTORY-3646,FACTORY-3644,FACTORY-3648,FACTORY-3645,FACTORY-3640,FACTORY-3643
 
 ; OPTIONAL The path to the mosaic config file if you want to use mosaic
-mosaic_config=configs/mosaic_config.Factory
+; mosaic_config=configs/mosaic_config.Factory
 
 
 


### PR DESCRIPTION
All the configuration options in the Mosaic configuration were
commented out causing finishline to traceback since it expected
certain keys to be set. This just disables Mosiac for Factory 2.0
entirely.